### PR TITLE
feat: Changing api to match with the newer version [DEVOP-2166]

### DIFF
--- a/modules/ksql-cluster/outputs.tf
+++ b/modules/ksql-cluster/outputs.tf
@@ -5,7 +5,7 @@ output "api_version" {
 
 output "http_endpoint" {
   description = "The API endpoint of this ksqlDB cluster."
-  value       = confluent_ksql_cluster.ksqldb_cluster.http_endpoint
+  value       = confluent_ksql_cluster.ksqldb_cluster.rest_endpoint
 }
 
 output "id" {

--- a/modules/ksql-cluster/providers.tf
+++ b/modules/ksql-cluster/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     confluent = {
       source  = "confluentinc/confluent"
-      version = ">= 1.2.0"
+      version = ">= 1.16.0"
     }
   }
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

The newer version of confluent provider is breaking change the API from `http_endpoint` to `rest_endpoint`
- from https://registry.terraform.io/providers/confluentinc/confluent/1.13.0/docs/data-sources/confluent_ksql_cluster#http_endpoint
- to https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/data-sources/confluent_ksql_cluster#rest_endpoint

This PR will fix our module to match with the new API and fix the plan erroring in https://github.com/honestbank/kafka-infrastructure

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/10)
<!-- Reviewable:end -->
