### PR TITLE
fix: avoid recreation of connector on status change

### DIFF
--- a/modules/connector/main.tf
+++ b/modules/connector/main.tf
@@ -44,4 +44,10 @@ resource "confluent_connector" "connector" {
   config_nonsensitive = local.config_nonsensitive
 
   config_sensitive = local.config_sensitive
+
+  lifecycle {
+    ignore_changes = [
+      status,
+    ]
+  }
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Avoids destroying and recreating a connector if its status changed. This is causing that, for example, if one of the multiple topics in the connector are not available and the status goes to 'FAILED', the Terraform provider wants to destroy the whole connector and recreate it. Instead, we should not maintain the status property with Terraform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/17)
<!-- Reviewable:end -->
