### PR TITLE
chore: update version of cycjimmy/semantic-release-action that is outdated and failing

### DIFF
--- a/.github/workflows/repository-terratest.yml
+++ b/.github/workflows/repository-terratest.yml
@@ -36,7 +36,7 @@ jobs:
           go test -v -timeout 60m
       - name: Release
         if: github.event_name == 'push'
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION


<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description
 This PR upgrades the version of the action `cycjimmy/semantic-release-action` as it is currently outdated and failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/18)
<!-- Reviewable:end -->
