### PR TITLE
feat: add permissions to read topics into the 'connector-service-acco…

### DIFF
--- a/modules/connector-service-account/inputs.tf
+++ b/modules/connector-service-account/inputs.tf
@@ -7,3 +7,9 @@ variable "kafka_cluster_id" {
   type        = string
   description = "(Required) The id of the kafka cluster"
 }
+
+variable "topics" {
+  type        = list(string)
+  description = "List of topics to which the connector service account should get READ access."
+  default     = []
+}

--- a/modules/connector-service-account/main.tf
+++ b/modules/connector-service-account/main.tf
@@ -1,3 +1,7 @@
+locals {
+  connector_service_account_principal = "User:${var.service_account_id}"
+}
+
 resource "confluent_kafka_acl" "connector_describe_on_cluster" {
   kafka_cluster {
     id = var.kafka_cluster_id
@@ -5,7 +9,7 @@ resource "confluent_kafka_acl" "connector_describe_on_cluster" {
   resource_type = "CLUSTER"
   resource_name = "kafka-cluster"
   pattern_type  = "LITERAL"
-  principal     = "User:${var.service_account_id}"
+  principal     = local.connector_service_account_principal
   host          = "*"
   operation     = "DESCRIBE"
   permission    = "ALLOW"
@@ -18,7 +22,7 @@ resource "confluent_kafka_acl" "connector_create_on_dlq_lcc_topics" {
   resource_type = "TOPIC"
   resource_name = "dlq-lcc"
   pattern_type  = "PREFIXED"
-  principal     = "User:${var.service_account_id}"
+  principal     = local.connector_service_account_principal
   host          = "*"
   operation     = "CREATE"
   permission    = "ALLOW"
@@ -31,7 +35,7 @@ resource "confluent_kafka_acl" "connector_write_on_dlq_lcc_topics" {
   resource_type = "TOPIC"
   resource_name = "dlq-lcc"
   pattern_type  = "PREFIXED"
-  principal     = "User:${var.service_account_id}"
+  principal     = local.connector_service_account_principal
   host          = "*"
   operation     = "WRITE"
   permission    = "ALLOW"
@@ -44,7 +48,22 @@ resource "confluent_kafka_acl" "app_connector_read_on_connect_lcc_group" {
   resource_type = "GROUP"
   resource_name = "connect-lcc"
   pattern_type  = "PREFIXED"
-  principal     = "User:${var.service_account_id}"
+  principal     = local.connector_service_account_principal
+  host          = "*"
+  operation     = "READ"
+  permission    = "ALLOW"
+}
+
+# See https://docs.confluent.io/cloud/current/connectors/service-account.html#example-configuring-a-service-account
+resource "confluent_kafka_acl" "connector_can_read_topics" {
+  for_each = toset(var.topics)
+  kafka_cluster {
+    id = var.kafka_cluster_id
+  }
+  resource_type = "TOPIC"
+  resource_name = each.value
+  pattern_type  = "LITERAL"
+  principal     = local.connector_service_account_principal
   host          = "*"
   operation     = "READ"
   permission    = "ALLOW"


### PR DESCRIPTION
…unt' component

<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Adds missing permissions to read the topics of a connector using the service account of the connector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/19)
<!-- Reviewable:end -->
