### PR TITLE
feat: Make kafka_acl_consumer optional

### DIFF
--- a/modules/kafka-topic/README.md
+++ b/modules/kafka-topic/README.md
@@ -32,7 +32,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | (Required) The ID of the cluster | `string` | n/a | yes |
 | <a name="input_connector_service_account_id"></a> [connector\_service\_account\_id](#input\_connector\_service\_account\_id) | (Required) The ID of the service account managing kafka connector | `string` | n/a | yes |
-| <a name="input_consumer_prefix"></a> [consumer\_prefix](#input\_consumer\_prefix) | (Required) The prefix of the consumer group, by default | `string` | n/a | yes |
+| <a name="input_consumer_prefix"></a> [consumer\_prefix](#input\_consumer\_prefix) | The prefix of the consumer group, meant for the consumer access control. By default no access control for consumers. | `string` | `null` | no |
 | <a name="input_delete_policy"></a> [delete\_policy](#input\_delete\_policy) | Delete policy, available values: delete or compact | `string` | `"delete"` | no |
 | <a name="input_delete_retention_ms"></a> [delete\_retention\_ms](#input\_delete\_retention\_ms) | The amount of time to retain delete tombstone markers for log compacted topics. | `string` | `null` | no |
 | <a name="input_max_compaction_lag_ms"></a> [max\_compaction\_lag\_ms](#input\_max\_compaction\_lag\_ms) | The maximum time a message will remain ineligible for compaction in the log. Only applicable for logs that are being compacted. | `string` | `null` | no |

--- a/modules/kafka-topic/inputs.tf
+++ b/modules/kafka-topic/inputs.tf
@@ -72,7 +72,8 @@ variable "min_compaction_lag_ms" {
 
 variable "consumer_prefix" {
   type        = string
-  description = "(Required) The prefix of the consumer group, by default"
+  description = "The prefix of the consumer group, meant for the consumer access control. By default no access control for consumers."
+  default     = null
 }
 
 variable "connector_service_account_id" {

--- a/modules/kafka-topic/main.tf
+++ b/modules/kafka-topic/main.tf
@@ -71,6 +71,7 @@ resource "confluent_kafka_acl" "kafka_acl_consumer" {
   host          = local.HOST_WILDCARD
   operation     = local.OPERATION_READ
   permission    = local.PERMISSION_ALLOW
+  count         = var.consumer_prefix != null ? 1 : 0
 }
 
 resource "confluent_kafka_acl" "connector_read_target_topic" {

--- a/modules/kafka-topic/main.tf
+++ b/modules/kafka-topic/main.tf
@@ -60,6 +60,8 @@ resource "confluent_kafka_acl" "kafka_acl_read" {
 }
 
 resource "confluent_kafka_acl" "kafka_acl_consumer" {
+  count         = var.consumer_prefix != null ? 1 : 0
+
   kafka_cluster {
     id = var.cluster_id
   }
@@ -71,7 +73,6 @@ resource "confluent_kafka_acl" "kafka_acl_consumer" {
   host          = local.HOST_WILDCARD
   operation     = local.OPERATION_READ
   permission    = local.PERMISSION_ALLOW
-  count         = var.consumer_prefix != null ? 1 : 0
 }
 
 resource "confluent_kafka_acl" "connector_read_target_topic" {


### PR DESCRIPTION

<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

In order to remove the restriction on the consumer group name prefixes.

https://linear.app/honestbank/issue/DEC-4037/make-kafka-acl-consumer-optional-in-terraform-confluent-kafka

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/23)
<!-- Reviewable:end -->
