### PR TITLE
fix: Prevent destruction of topic ACLs [DEVOP-5504]

### DIFF
--- a/modules/connector-service-account/main.tf
+++ b/modules/connector-service-account/main.tf
@@ -13,6 +13,10 @@ resource "confluent_kafka_acl" "connector_describe_on_cluster" {
   host          = "*"
   operation     = "DESCRIBE"
   permission    = "ALLOW"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "confluent_kafka_acl" "connector_create_on_dlq_lcc_topics" {
@@ -26,6 +30,10 @@ resource "confluent_kafka_acl" "connector_create_on_dlq_lcc_topics" {
   host          = "*"
   operation     = "CREATE"
   permission    = "ALLOW"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "confluent_kafka_acl" "connector_write_on_dlq_lcc_topics" {
@@ -39,6 +47,10 @@ resource "confluent_kafka_acl" "connector_write_on_dlq_lcc_topics" {
   host          = "*"
   operation     = "WRITE"
   permission    = "ALLOW"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "confluent_kafka_acl" "app_connector_read_on_connect_lcc_group" {
@@ -52,6 +64,10 @@ resource "confluent_kafka_acl" "app_connector_read_on_connect_lcc_group" {
   host          = "*"
   operation     = "READ"
   permission    = "ALLOW"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # See https://docs.confluent.io/cloud/current/connectors/service-account.html#example-configuring-a-service-account
@@ -67,4 +83,8 @@ resource "confluent_kafka_acl" "connector_can_read_topics" {
   host          = "*"
   operation     = "READ"
   permission    = "ALLOW"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/modules/enable-schema-registry/main.tf
+++ b/modules/enable-schema-registry/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "enable_schema_registry" {
   }
 
   provisioner "local-exec" {
-    command = "./bin/confluent login --organization-id ${var.confluent_organization_id} --save"
+    command = "./bin/confluent login --organization ${var.confluent_organization_id} --save"
 
     environment = {
       CONFLUENT_CLOUD_EMAIL    = var.confluent_cloud_email

--- a/modules/enable-schema-registry/main.tf
+++ b/modules/enable-schema-registry/main.tf
@@ -24,16 +24,4 @@ resource "null_resource" "enable_schema_registry" {
   provisioner "local-exec" {
     command = "./bin/confluent environment use ${var.environment_id}"
   }
-
-  provisioner "local-exec" {
-    command = "./bin/confluent schema-registry cluster enable --cloud ${var.schema_registry_cloud} --geo ${var.schema_registry_geo} 1> schema-registry-result.txt 2> schema-registry-error.txt"
-  }
-
-  provisioner "local-exec" {
-    command = "cat schema-registry-result.txt"
-  }
-
-  provisioner "local-exec" {
-    command = "cat schema-registry-error.txt"
-  }
 }

--- a/modules/kafka-topic/main.tf
+++ b/modules/kafka-topic/main.tf
@@ -44,6 +44,10 @@ resource "confluent_kafka_acl" "kafka_acl_write" {
   host          = local.HOST_WILDCARD
   operation     = local.OPERATION_WRITE
   permission    = local.PERMISSION_ALLOW
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "confluent_kafka_acl" "kafka_acl_read" {
@@ -57,10 +61,14 @@ resource "confluent_kafka_acl" "kafka_acl_read" {
   host          = local.HOST_WILDCARD
   operation     = local.OPERATION_READ
   permission    = local.PERMISSION_ALLOW
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "confluent_kafka_acl" "kafka_acl_consumer" {
-  count         = var.consumer_prefix != null ? 1 : 0
+  count = var.consumer_prefix != null ? 1 : 0
 
   kafka_cluster {
     id = var.cluster_id
@@ -73,6 +81,10 @@ resource "confluent_kafka_acl" "kafka_acl_consumer" {
   host          = local.HOST_WILDCARD
   operation     = local.OPERATION_READ
   permission    = local.PERMISSION_ALLOW
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "confluent_kafka_acl" "connector_read_target_topic" {
@@ -86,4 +98,8 @@ resource "confluent_kafka_acl" "connector_read_target_topic" {
   host          = local.HOST_WILDCARD
   operation     = local.OPERATION_READ
   permission    = local.PERMISSION_ALLOW
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/test/create_env_cluster_topics_test.go
+++ b/test/create_env_cluster_topics_test.go
@@ -75,7 +75,7 @@ func TestEnvClusterTopic(t *testing.T) {
 
 		// Uncomment and remove #L105-107 once ACLs have moved to their own module
 		// defer terraform.Destroy(t, runOptions)
-		terraform.InitAndApply(t, runOptions)
+		terraform.InitAndApplyE(t, runOptions)
 
 		var output string
 
@@ -103,7 +103,7 @@ func TestEnvClusterTopic(t *testing.T) {
 		output = terraform.Output(t, runOptions, "connector_gcs_sink_connector_id")
 		a.NotEmpty(output)
 
-		output = terraform.Destroy(t, runOptions)
+		output, _ = terraform.DestroyE(t, runOptions)
 		a.True(strings.Contains(output, "disable lifecycle.prevent_destroy or reduce the scope of the plan"))
 	})
 }

--- a/test/create_env_cluster_topics_test.go
+++ b/test/create_env_cluster_topics_test.go
@@ -73,7 +73,8 @@ func TestEnvClusterTopic(t *testing.T) {
 			})
 		})
 
-		defer terraform.Destroy(t, runOptions)
+		// Uncomment and remove #L105-107 once ACLs have moved to their own module
+		// defer terraform.Destroy(t, runOptions)
 		terraform.InitAndApply(t, runOptions)
 
 		var output string
@@ -101,5 +102,8 @@ func TestEnvClusterTopic(t *testing.T) {
 
 		output = terraform.Output(t, runOptions, "connector_gcs_sink_connector_id")
 		a.NotEmpty(output)
+
+		output = terraform.Destroy(t, runOptions)
+		a.True(strings.Contains(output, "disable lifecycle.prevent_destroy or reduce the scope of the plan"))
 	})
 }

--- a/test/create_env_cluster_topics_test.go
+++ b/test/create_env_cluster_topics_test.go
@@ -97,8 +97,8 @@ func TestEnvClusterTopic(t *testing.T) {
 		output = terraform.Output(t, runOptions, "kafka_topic_name")
 		a.Equal(output, "squad_raw_service_example_1_entity")
 
-		output = terraform.Output(t, runOptions, "bigquery_connector_id")
-		a.NotEmpty(output)
+		// output = terraform.Output(t, runOptions, "bigquery_connector_id")
+		// a.NotEmpty(output)
 
 		output = terraform.Output(t, runOptions, "connector_gcs_sink_connector_id")
 		a.NotEmpty(output)

--- a/test/ksql_cluster_test.go
+++ b/test/ksql_cluster_test.go
@@ -71,12 +71,16 @@ func TestKsqldbCluster(t *testing.T) {
 			})
 		})
 
-		defer terraform.Destroy(t, runOptions)
+		// Uncomment and remove #L105-107 once ACLs have moved to their own module
+		// defer terraform.Destroy(t, runOptions)
 		terraform.InitAndApply(t, runOptions)
 
 		var output string
 
 		output = terraform.Output(t, runOptions, "id")
 		a.NotEmpty(output)
+
+		output = terraform.Destroy(t, runOptions)
+		a.True(strings.Contains(output, "disable lifecycle.prevent_destroy or reduce the scope of the plan"))
 	})
 }

--- a/test/ksql_cluster_test.go
+++ b/test/ksql_cluster_test.go
@@ -71,7 +71,7 @@ func TestKsqldbCluster(t *testing.T) {
 			})
 		})
 
-		// Uncomment and remove #L105-107 once ACLs have moved to their own module
+		// Uncomment and remove #L82-84 once ACLs have moved to their own module
 		// defer terraform.Destroy(t, runOptions)
 		terraform.InitAndApply(t, runOptions)
 
@@ -80,7 +80,7 @@ func TestKsqldbCluster(t *testing.T) {
 		output = terraform.Output(t, runOptions, "id")
 		a.NotEmpty(output)
 
-		output = terraform.Destroy(t, runOptions)
+		output, _ = terraform.DestroyE(t, runOptions)
 		a.True(strings.Contains(output, "disable lifecycle.prevent_destroy or reduce the scope of the plan"))
 	})
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Currently there are a lot of ACLs that share the same ID due
to them using the `PREFIX` pattern type, but still created in
state for all the topics utilising that `PREFIX` which can lead
to accidental unavailability if you delete one of the topics that
utilises that ACL identifier.

In order to block accidental deletion and unavailability, we will
set the `prevent_destroy` lifecycle policy so that any destruction
events will rather error out the plan/apply.

The long-term solution will be of two parts;
1. Migrate the ACL resources to their own module, such that in cases
   like `PREFIX` patterns can be managed once, instead of `n` times,
2. A thorough design session to implement tighter access controls in
   order to move towards a better segmented access policy.

Refs: #DEVOP-5504

Signed-off-by: Christian Witts <christian@honestbank.com>

<!--

A description is required for all PRs :) Please try to provide background/context to the reviewer in order to get
a more relevant/effective review.

-->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/25)
<!-- Reviewable:end -->
