### PR TITLE
feat: Add feature to create metrics service account [DEVOP-5520]

### DIFF
--- a/modules/enable-schema-registry/main.tf
+++ b/modules/enable-schema-registry/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "enable_schema_registry" {
   }
 
   provisioner "local-exec" {
-    command = "./bin/confluent login --organization-id ${var.confluent_organization_id} --save"
+    command = "./bin/confluent login --organization ${var.confluent_organization_id} --save"
 
     environment = {
       CONFLUENT_CLOUD_EMAIL    = var.confluent_cloud_email

--- a/modules/kafka-topic/main.tf
+++ b/modules/kafka-topic/main.tf
@@ -60,7 +60,7 @@ resource "confluent_kafka_acl" "kafka_acl_read" {
 }
 
 resource "confluent_kafka_acl" "kafka_acl_consumer" {
-  count         = var.consumer_prefix != null ? 1 : 0
+  count = var.consumer_prefix != null ? 1 : 0
 
   kafka_cluster {
     id = var.cluster_id

--- a/modules/service-account/README.md
+++ b/modules/service-account/README.md
@@ -22,16 +22,19 @@ No modules.
 | Name | Type |
 |------|------|
 | [confluent_api_key.service_account_kafka_api_key](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/api_key) | resource |
+| [confluent_role_binding.service_account_for_metrics](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/role_binding) | resource |
 | [confluent_service_account.service_account](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/service_account) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_api_version"></a> [cluster\_api\_version](#input\_cluster\_api\_version) | API version of the Kafka cluster | `string` | n/a | yes |
-| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ID of the Kafka cluster | `string` | n/a | yes |
-| <a name="input_cluster_kind"></a> [cluster\_kind](#input\_cluster\_kind) | The kind of the Kafka cluster | `string` | n/a | yes |
-| <a name="input_environment_id"></a> [environment\_id](#input\_environment\_id) | The ID of the Confluent environment | `string` | n/a | yes |
+| <a name="input_cluster_api_version"></a> [cluster\_api\_version](#input\_cluster\_api\_version) | API version of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_cluster_crn"></a> [cluster\_crn](#input\_cluster\_crn) | The Confluent Resource Name of the Kafka cluster, for example, `crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/cloud-cluster=lkc-abc123`. This value cannot be blank if `is_metrics_service_account` is set to `true` | `string` | `null` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ID of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_cluster_kind"></a> [cluster\_kind](#input\_cluster\_kind) | The kind of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_environment_id"></a> [environment\_id](#input\_environment\_id) | The ID of the Confluent environment. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_is_metrics_service_account"></a> [is\_metrics\_service\_account](#input\_is\_metrics\_service\_account) | Set this value to true if you want to create a service account for metrics export else false | `bool` | `false` | no |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The name of the service account | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/service-account/input.tf
+++ b/modules/service-account/input.tf
@@ -16,20 +16,36 @@ variable "service_account_name" {
 
 variable "cluster_id" {
   type        = string
-  description = "The ID of the Kafka cluster"
+  description = "The ID of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
 }
 
 variable "cluster_api_version" {
   type        = string
-  description = "API version of the Kafka cluster"
+  description = "API version of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
 }
 
 variable "cluster_kind" {
   type        = string
-  description = "The kind of the Kafka cluster"
+  description = "The kind of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
 }
 
 variable "environment_id" {
   type        = string
-  description = "The ID of the Confluent environment"
+  description = "The ID of the Confluent environment. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
+}
+
+variable "is_metrics_service_account" {
+  type        = bool
+  description = "Set this value to true if you want to create a service account for metrics export else false"
+  default     = false
+}
+
+variable "cluster_crn" {
+  type        = string
+  description = "The Confluent Resource Name of the Kafka cluster, for example, `crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/cloud-cluster=lkc-abc123`. This value cannot be blank if `is_metrics_service_account` is set to `true`"
+  default     = null
 }

--- a/modules/service-account/main.tf
+++ b/modules/service-account/main.tf
@@ -12,13 +12,23 @@ resource "confluent_api_key" "service_account_kafka_api_key" {
     kind        = confluent_service_account.service_account.kind
   }
 
-  managed_resource {
-    id          = var.cluster_id
-    api_version = var.cluster_api_version
-    kind        = var.cluster_kind
+  dynamic "managed_resource" {
+    for_each = var.is_metrics_service_account ? [] : [1]
+    content {
+      id          = var.cluster_id
+      api_version = var.cluster_api_version
+      kind        = var.cluster_kind
 
-    environment {
-      id = var.environment_id
+      environment {
+        id = var.environment_id
+      }
     }
   }
+}
+
+resource "confluent_role_binding" "service_account_for_metrics" {
+  count       = var.is_metrics_service_account ? 1 : 0
+  principal   = "User:${confluent_service_account.service_account.id}"
+  role_name   = "MetricsViewer"
+  crn_pattern = var.cluster_crn
 }


### PR DESCRIPTION
Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description
Add a option to create a service account which has access only to Metrics, which can be used in the prometheus scraping config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/26)
<!-- Reviewable:end -->
