### PR TITLE
feat: Add feature to create metrics service account [DEVOP-5520]

### DIFF
--- a/.github/workflows/repository-terratest.yml
+++ b/.github/workflows/repository-terratest.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.8.5"
+          terraform_version: "1.9.0"
       - name: Install Confluent CLI
         run: |
           # Download and install Confluent CLI

--- a/examples/create-env-cluster-topics/main.tf
+++ b/examples/create-env-cluster-topics/main.tf
@@ -62,6 +62,13 @@ module "honest_labs_connector_service_account" {
   service_account_name = var.connector_service_account_name
 }
 
+module "honest_labs_connector_metrics_service_account" {
+  source                     = "../../modules/service-account"
+  is_metrics_service_account = true
+  service_account_name       = "metrics-${var.connector_service_account_name}"
+  cluster_crn                = module.honest_labs_kafka_cluster_basic.rbac_crn
+}
+
 module "honest_labs_connector_service_account_grant_permission" {
   source = "../../modules/connector-service-account"
 

--- a/modules/service-account/README.md
+++ b/modules/service-account/README.md
@@ -22,16 +22,19 @@ No modules.
 | Name | Type |
 |------|------|
 | [confluent_api_key.service_account_kafka_api_key](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/api_key) | resource |
+| [confluent_role_binding.service_account_for_metrics](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/role_binding) | resource |
 | [confluent_service_account.service_account](https://registry.terraform.io/providers/confluentinc/confluent/latest/docs/resources/service_account) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_api_version"></a> [cluster\_api\_version](#input\_cluster\_api\_version) | API version of the Kafka cluster | `string` | n/a | yes |
-| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ID of the Kafka cluster | `string` | n/a | yes |
-| <a name="input_cluster_kind"></a> [cluster\_kind](#input\_cluster\_kind) | The kind of the Kafka cluster | `string` | n/a | yes |
-| <a name="input_environment_id"></a> [environment\_id](#input\_environment\_id) | The ID of the Confluent environment | `string` | n/a | yes |
+| <a name="input_cluster_api_version"></a> [cluster\_api\_version](#input\_cluster\_api\_version) | API version of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_cluster_crn"></a> [cluster\_crn](#input\_cluster\_crn) | The Confluent Resource Name of the Kafka cluster, for example, `crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/cloud-cluster=lkc-abc123`. This value cannot be blank if `is_metrics_service_account` is set to `true` | `string` | `null` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The ID of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_cluster_kind"></a> [cluster\_kind](#input\_cluster\_kind) | The kind of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_environment_id"></a> [environment\_id](#input\_environment\_id) | The ID of the Confluent environment. This value cannot be blank if `is_metrics_service_account` is set to `false` | `string` | `null` | no |
+| <a name="input_is_metrics_service_account"></a> [is\_metrics\_service\_account](#input\_is\_metrics\_service\_account) | Set this value to true if you want to create a service account for metrics export else false | `bool` | `false` | no |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The name of the service account | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/service-account/input.tf
+++ b/modules/service-account/input.tf
@@ -16,20 +16,67 @@ variable "service_account_name" {
 
 variable "cluster_id" {
   type        = string
-  description = "The ID of the Kafka cluster"
+  description = "The ID of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
+
+  validation {
+    condition     = var.is_metrics_service_account || (var.cluster_id != null && var.cluster_id != "")
+    error_message = "The cluster_id cannot be blank when is_metrics_service_account is set to false."
+  }
 }
 
 variable "cluster_api_version" {
   type        = string
-  description = "API version of the Kafka cluster"
+  description = "API version of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
+
+  validation {
+    condition     = var.is_metrics_service_account || (var.cluster_api_version != null && var.cluster_api_version != "")
+    error_message = "The cluster_api_version cannot be blank when is_metrics_service_account is set to false."
+  }
 }
 
 variable "cluster_kind" {
   type        = string
-  description = "The kind of the Kafka cluster"
+  description = "The kind of the Kafka cluster. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
+
+  validation {
+    condition     = var.is_metrics_service_account || (var.cluster_kind != null && var.cluster_kind != "")
+    error_message = "The cluster_kind cannot be blank when is_metrics_service_account is set to false."
+  }
 }
 
 variable "environment_id" {
   type        = string
-  description = "The ID of the Confluent environment"
+  description = "The ID of the Confluent environment. This value cannot be blank if `is_metrics_service_account` is set to `false`"
+  default     = null
+
+  validation {
+    condition     = var.is_metrics_service_account || (var.environment_id != null && var.environment_id != "")
+    error_message = "The environment_id cannot be blank when is_metrics_service_account is set to false."
+  }
+}
+
+variable "is_metrics_service_account" {
+  type        = bool
+  description = "Set this value to true if you want to create a service account for metrics export else false"
+  default     = false
+}
+
+variable "cluster_crn" {
+  type        = string
+  description = "The Confluent Resource Name of the Kafka cluster, for example, `crn://confluent.cloud/organization=1111aaaa-11aa-11aa-11aa-111111aaaaaa/environment=env-abc123/cloud-cluster=lkc-abc123`. This value cannot be blank if `is_metrics_service_account` is set to `true`"
+  default     = null
+
+  validation {
+    condition = (
+      var.is_metrics_service_account == false || (
+        var.cluster_crn != null &&
+        var.cluster_crn != "" &&
+        can(regex("^crn://confluent.cloud/organization=[a-f0-9-]+/environment=env-[a-z0-9]+/cloud-cluster=lkc-[a-z0-9]+$", var.cluster_crn))
+      )
+    )
+    error_message = "The 'cluster_crn' must be a valid Confluent Resource Name (CRN) in the format 'crn://confluent.cloud/organization=<UUID>/environment=env-<ID>/cloud-cluster=lkc-<ID>' and cannot be blank if 'is_metrics_service_account' is set to 'true'."
+  }
 }

--- a/modules/service-account/providers.tf
+++ b/modules/service-account/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.9"
 
   required_providers {
     confluent = {

--- a/test/create_env_cluster_topics_test.go
+++ b/test/create_env_cluster_topics_test.go
@@ -173,14 +173,17 @@ func TestEnvClusterTopic(t *testing.T) {
 
 		for _, account := range serviceAccounts {
 			if account["name"] == adminServiceAccountName {
-				a.Equal(adminServiceAccountName, account["name"], "Admin service account name is not crrect.")
+				a.Equal(adminServiceAccountName, account["name"], "Admin service account name is not correct.")
 				log.Printf("Admin service account '%s' validated successfully.", adminServiceAccountName)
 			} else if account["name"] == topicServiceAccountName {
-				a.Equal(topicServiceAccountName, account["name"], "Topic service account name is not crrect.")
+				a.Equal(topicServiceAccountName, account["name"], "Topic service account name is not correct.")
 				log.Printf("Topic Service Account '%s' validated successfully.", topicServiceAccountName)
 			} else if account["name"] == connectorServiceAccountName {
-				a.Equal(connectorServiceAccountName, account["name"], "Connector service sccount name is not correct.")
+				a.Equal(connectorServiceAccountName, account["name"], "Connector service account name is not correct.")
 				log.Printf("Connector service account '%s' validated successfully.", connectorServiceAccountName)
+			} else if account["name"] == "metrics-"+connectorServiceAccountName {
+				a.Equal("metrics-"+connectorServiceAccountName, account["name"], "Metrics service account name is not correct.")
+				log.Printf("Metrics service account '%s' validated successfully.", "metrics"+connectorServiceAccountName)
 			}
 		}
 


### PR DESCRIPTION
Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description
- Currently the service account used in prometheus to scrape metrics off the confluent clusters has admin privileges.
- Confluent provides an option to create a metrics service account explicitly for this purpose.
- We are adding an option to create a metrics service account in the current service account module.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-confluent-kafka/31)
<!-- Reviewable:end -->
