### PR TITLE
feat: Gate the API key creation based on cluster ID [DEVOP-7531]

### DIFF
--- a/modules/cluster-admin/main.tf
+++ b/modules/cluster-admin/main.tf
@@ -10,12 +10,16 @@ resource "confluent_role_binding" "admin_environment" {
 }
 
 resource "confluent_role_binding" "admin_cluster" {
+  count = var.cluster_id == "" ? 0 : 1
+
   principal   = "User:${confluent_service_account.admin.id}"
   role_name   = "CloudClusterAdmin"
   crn_pattern = var.cluster_rbac_crn
 }
 
 resource "confluent_api_key" "admin_kafka_api_key" {
+  count = var.cluster_id == "" ? 0 : 1
+
   display_name = "${confluent_service_account.admin.display_name}-kafka-api-key"
   description  = "Kafka API Key that is owned by '${confluent_service_account.admin.display_name}' service account"
 

--- a/modules/cluster-admin/outputs.tf
+++ b/modules/cluster-admin/outputs.tf
@@ -10,12 +10,12 @@ output "admin_service_account_id" {
 
 output "admin_kafka_api_key" {
   description = "Kafka API Key to manage kafka resources - topics, ACL on topics"
-  value       = confluent_api_key.admin_kafka_api_key.id
+  value       = try(confluent_api_key.admin_kafka_api_key[0].id, "")
 }
 
 output "admin_kafka_api_secret" {
   description = "Kafka API Secret to manage kafka resources - topics, ACL on topics"
-  value       = confluent_api_key.admin_kafka_api_key.secret
+  value       = try(confluent_api_key.admin_kafka_api_key[0].secret, "")
   sensitive   = true
 }
 


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

This PR gates the API key creation based on cluster_id input variable.  

Why?
The cluster ID of standard cluster is `""` in qa & prod. This changes helps avoid Terraform plan errors.
